### PR TITLE
Add support for importing Atomic nodes

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -39,6 +39,7 @@ namespace clang {
 
     // Importing types
     QualType VisitType(const Type *T);
+    QualType VisitAtomicType(const AtomicType *T);
     QualType VisitBuiltinType(const BuiltinType *T);
     QualType VisitDecayedType(const DecayedType *T);
     QualType VisitComplexType(const ComplexType *T);
@@ -1598,6 +1599,14 @@ QualType ASTNodeImporter::VisitType(const Type *T) {
   Importer.FromDiag(SourceLocation(), diag::err_unsupported_ast_node)
     << T->getTypeClassName();
   return QualType();
+}
+
+QualType ASTNodeImporter::VisitAtomicType(const AtomicType *T){
+  QualType UnderlyingType = Importer.Import(T->getValueType());
+  if (UnderlyingType.isNull())
+    return QualType();
+
+  return Importer.getToContext().getAtomicType(UnderlyingType);
 }
 
 QualType ASTNodeImporter::VisitBuiltinType(const BuiltinType *T) {

--- a/unittests/AST/ASTImporterTest.cpp
+++ b/unittests/AST/ASTImporterTest.cpp
@@ -101,6 +101,21 @@ testImport(const std::string &FromCode, Language FromLang,
   return Verifier.match(Imported, AMatcher);
 }
 
+TEST(ImportExpr, ImportAtomic) {
+  MatchVerifier<Decl> Verifier;
+  EXPECT_TRUE(testImport("void declToImport() { typedef _Atomic(int) a; }",
+                         Lang_CXX, "", Lang_CXX, Verifier,
+                         functionDecl(
+                           hasBody(
+                             compoundStmt(
+                               has(
+                                 declStmt(
+                                   has(
+                                     typedefDecl(
+                                       has(
+                                         atomicType()))))))))));
+}
+
 TEST(ImportExpr, ImportStringLiteral) {
   MatchVerifier<Decl> Verifier;
   EXPECT_TRUE(testImport("void declToImport() { \"foo\"; }",


### PR DESCRIPTION
This commit adds a visitor for AtomicType nodes in ASTNodeImporter, so
that AtomicType nodes can be imported. Also added a test for this
functionality.

This commit fixes #10.