### PR TITLE
Correctly initialize SubStmt of CaseStmt

### DIFF
--- a/include/clang/AST/Stmt.h
+++ b/include/clang/AST/Stmt.h
@@ -693,9 +693,10 @@ class CaseStmt : public SwitchCase {
                              // GNU "case 1 ... 4" extension
 public:
   CaseStmt(Expr *lhs, Expr *rhs, SourceLocation caseLoc,
-           SourceLocation ellipsisLoc, SourceLocation colonLoc)
+           SourceLocation ellipsisLoc, SourceLocation colonLoc,
+           Stmt *SubStmt=nullptr)
     : SwitchCase(CaseStmtClass, caseLoc, colonLoc) {
-    SubExprs[SUBSTMT] = nullptr;
+    SubExprs[SUBSTMT] = SubStmt;
     SubExprs[LHS] = reinterpret_cast<Stmt*>(lhs);
     SubExprs[RHS] = reinterpret_cast<Stmt*>(rhs);
     EllipsisLoc = ellipsisLoc;

--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -5124,12 +5124,15 @@ Stmt *ASTNodeImporter::VisitCaseStmt(CaseStmt *S) {
   Expr *ToRHS = Importer.Import(S->getRHS());
   if (!ToRHS && S->getRHS())
     return nullptr;
+  Stmt *ToSubStmt = Importer.Import(S->getSubStmt());
+  if (!ToSubStmt && S->getSubStmt())
+    return nullptr;
   SourceLocation ToCaseLoc = Importer.Import(S->getCaseLoc());
   SourceLocation ToEllipsisLoc = Importer.Import(S->getEllipsisLoc());
   SourceLocation ToColonLoc = Importer.Import(S->getColonLoc());
   return new (Importer.getToContext()) CaseStmt(ToLHS, ToRHS,
                                                 ToCaseLoc, ToEllipsisLoc,
-                                                ToColonLoc);
+                                                ToColonLoc, ToSubStmt);
 }
 
 Stmt *ASTNodeImporter::VisitDefaultStmt(DefaultStmt *S) {


### PR DESCRIPTION
There is now the option to construct a CaseStmt with a sub statement;
previously, the only way to set a CaseStmt's SubStmt field was to call
the setter function, and this function is not called from anywhere in
the codebase.

This new constructor is used by the AST Importer when importing case
statements.

This commit fixes #23.
