### PR TITLE
Fixes #41

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -2674,15 +2674,27 @@ Decl *ASTNodeImporter::VisitTypedefNameDecl(TypedefNameDecl *D, bool IsAlias) {
       if (!FoundDecls[I]->isInIdentifierNamespace(IDNS))
         continue;
       if (TypedefNameDecl *FoundTypedef =
-            dyn_cast<TypedefNameDecl>(FoundDecls[I])) {
-        if (Importer.IsStructurallyEquivalent(D->getUnderlyingType(),
-                                            FoundTypedef->getUnderlyingType()))
-          return Importer.Imported(D, FoundTypedef);
+              dyn_cast<TypedefNameDecl>(FoundDecls[I])) {
+        if (Importer.IsStructurallyEquivalent(
+                D->getUnderlyingType(), FoundTypedef->getUnderlyingType())) {
+          QualType original_ut = D->getUnderlyingType();
+          QualType found_ut = FoundTypedef->getUnderlyingType();
+          // If the found definition is incomplete
+          // but it should be complete import
+          // FIXME: maybe this check should go into
+          // IsStructurallyEquivalent() function?
+          if (!original_ut->isIncompleteType() &&
+              found_ut->isIncompleteType()) {
+            continue;
+          } else {
+            return Importer.Imported(D, FoundTypedef);
+          }
+        }
       }
-      
+
       ConflictingDecls.push_back(FoundDecls[I]);
     }
-    
+
     if (!ConflictingDecls.empty()) {
       Name = Importer.HandleNameConflict(Name, DC, IDNS,
                                          ConflictingDecls.data(), 
@@ -2691,7 +2703,6 @@ Decl *ASTNodeImporter::VisitTypedefNameDecl(TypedefNameDecl *D, bool IsAlias) {
         return nullptr;
     }
   }
-  
   // Import the underlying type of this typedef;
   QualType T = Importer.Import(D->getUnderlyingType());
   if (T.isNull())
@@ -2716,7 +2727,6 @@ Decl *ASTNodeImporter::VisitTypedefNameDecl(TypedefNameDecl *D, bool IsAlias) {
   ToTypedef->setLexicalDeclContext(LexicalDC);
   Importer.Imported(D, ToTypedef);
   LexicalDC->addDeclInternal(ToTypedef);
-  
   return ToTypedef;
 }
 

--- a/test/Analysis/Inputs/externalFnMap.txt
+++ b/test/Analysis/Inputs/externalFnMap.txt
@@ -12,3 +12,5 @@ _ZN4chns4chf3Ei@x86_64 xtu-other.cpp.ast
 _ZN5mycls3fclEi@x86_64 xtu-other.cpp.ast
 _ZN4chns4chf1Ei@x86_64 xtu-other.cpp.ast
 _ZN4myns8embed_ns4fensEi@x86_64 xtu-other.cpp.ast
+_Z7avtSizev@x86_64 xtu-other.cpp.ast
+_Z7h_chaini@x86_64 xtu-chain.cpp.ast

--- a/test/Analysis/Inputs/xtu-other.cpp
+++ b/test/Analysis/Inputs/xtu-other.cpp
@@ -65,3 +65,13 @@ int chf1(int x) {
   return chf2(x);
 }
 }
+
+//Test for a crash when importing
+//typedefs
+struct AVBuffer {
+	int a;
+};
+typedef struct AVBuffer avt;
+int avtSize(void){
+	return sizeof(avt);
+}

--- a/test/Analysis/xtu-main.cpp
+++ b/test/Analysis/xtu-main.cpp
@@ -39,6 +39,10 @@ public:
 namespace chns {
 int chf1(int x);
 }
+//test for a crash
+//when inlining typedefs
+typedef struct AVBuffer avt;
+int avtSize(void);
 
 int main() {
   clang_analyzer_eval(f(3) == 2); // expected-warning{{TRUE}}
@@ -46,13 +50,12 @@ int main() {
   clang_analyzer_eval(f(5) == 3); // expected-warning{{FALSE}}
   clang_analyzer_eval(g(4) == 6); // expected-warning{{TRUE}}
   clang_analyzer_eval(h(2) == 8); // expected-warning{{TRUE}}
-
   clang_analyzer_eval(myns::fns(2) == 9);                   // expected-warning{{TRUE}}
   clang_analyzer_eval(myns::embed_ns::fens(2) == -1);       // expected-warning{{TRUE}}
   clang_analyzer_eval(mycls().fcl(1) == 6);                 // expected-warning{{TRUE}}
   clang_analyzer_eval(mycls::fscl(1) == 7);                 // expected-warning{{TRUE}}
   clang_analyzer_eval(myns::embed_cls().fecl(1) == -6);     // expected-warning{{TRUE}}
   clang_analyzer_eval(mycls::embed_cls2().fecl2(0) == -11); // expected-warning{{TRUE}}
-
   clang_analyzer_eval(chns::chf1(4) == 12); // expected-warning{{TRUE}}
+  clang_analyzer_eval(avtSize() == 4); // expected-warning{{TRUE}}
 }


### PR DESCRIPTION
this patch fixes the assert we experienced in FFMPEG, when importing complete typedef on the top of an  incomplete typdef with the same name.