### PR TITLE
check unnamed struct equivalence if it isnt inside a record

### DIFF
--- a/lib/AST/ASTImporter.cpp
+++ b/lib/AST/ASTImporter.cpp
@@ -3054,6 +3054,9 @@ Decl *ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
               if (*Index1 != *Index2)
                 continue;
             }
+          } else {
+            if(!IsStructuralMatch(D, FoundRecord,false))
+              continue;
           }
         }
 

--- a/test/ASTMerge/struct/Inputs/struct1.c
+++ b/test/ASTMerge/struct/Inputs/struct1.c
@@ -123,3 +123,9 @@ struct DeepUnnamedError {
     long i;
   } V;
 } x14;
+
+// Global unnamed struct.
+struct {
+  int i;
+  int h[15];
+} x15;

--- a/test/ASTMerge/struct/Inputs/struct2.c
+++ b/test/ASTMerge/struct/Inputs/struct2.c
@@ -120,3 +120,9 @@ struct DeepUnnamedError {
     long i;
   } V;
 } x14;
+
+// Global unnamed struct.
+struct {
+  int i;
+  int h[16];
+} x16;


### PR DESCRIPTION
In case the unnamed struct is not inside a record the analyzer will give an error about importing more then one of them since it would be checked only in line 3065 (IsStructuralMatch function call which complain parameter is true by default).