### PR TITLE
We don't want to be smarter than the user.

### DIFF
--- a/tools/xtu-analysis/xtu-analyze.py
+++ b/tools/xtu-analysis/xtu-analyze.py
@@ -26,7 +26,7 @@ try:
 except:
     raise
 
-threading_factor = int(multiprocessing.cpu_count() * 1.5)
+threading_factor = int(multiprocessing.cpu_count() * 1.0)
 analyser_output_formats = ['plist-multi-file', 'plist', 'plist-html',
                            'html', 'text']
 analyser_output_format = analyser_output_formats[0]

--- a/tools/xtu-analysis/xtu-build.py
+++ b/tools/xtu-analysis/xtu-build.py
@@ -10,7 +10,7 @@ import signal
 import subprocess
 import string
 
-threading_factor = int(multiprocessing.cpu_count() * 1.5)
+threading_factor = int(multiprocessing.cpu_count() * 1.0)
 timeout = 86400
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
Let the user set tricky threading factors. Let's stay with a simple one.